### PR TITLE
feat: add Redis-based player messaging and utility for sending text

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.11-1.1.1-SNAPSHOT
+version=1.21.11-1.1.2-SNAPSHOT

--- a/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/SurfCoreApi.kt
+++ b/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/SurfCoreApi.kt
@@ -22,6 +22,16 @@ interface SurfCoreApi {
     fun getServerByCategory(category: String): ObjectSet<SurfServer>
     fun getServers(): ObjectSet<SurfServer>
 
+    /**
+     * Sends a text message to the given player via the cross-server messaging system.
+     *
+     * This method publishes the message through Redis so that it reaches the player
+     * regardless of which server in the network they are currently connected to.
+     * The delivery is asynchronous and is not limited to the local server instance.
+     *
+     * @param player the target player, which may be connected to any server in the network
+     * @param text the message component to send to the player
+     */
     fun sendText(player: SurfPlayer, text: Component)
 
     suspend fun getOfflinePlayer(name: String): SurfPlayer?

--- a/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/SurfCoreApi.kt
+++ b/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/SurfCoreApi.kt
@@ -4,6 +4,7 @@ import dev.slne.surf.core.api.common.player.SurfPlayer
 import dev.slne.surf.core.api.common.server.SurfServer
 import dev.slne.surf.surfapi.core.api.util.requiredService
 import it.unimi.dsi.fastutil.objects.ObjectSet
+import net.kyori.adventure.text.Component
 import java.util.*
 
 val surfCoreApi = requiredService<SurfCoreApi>()
@@ -20,6 +21,8 @@ interface SurfCoreApi {
     fun getServerByName(name: String): SurfServer?
     fun getServerByCategory(category: String): ObjectSet<SurfServer>
     fun getServers(): ObjectSet<SurfServer>
+
+    fun sendText(player: SurfPlayer, text: Component)
 
     suspend fun getOfflinePlayer(name: String): SurfPlayer?
     suspend fun getOfflinePlayer(uuid: UUID): SurfPlayer?

--- a/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/util/surf-player-util.kt
+++ b/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/util/surf-player-util.kt
@@ -5,5 +5,5 @@ import dev.slne.surf.core.api.common.surfCoreApi
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 
 inline fun SurfPlayer.sendText(text: SurfComponentBuilder.() -> Unit) {
-    surfCoreApi.sendText(this, SurfComponentBuilder().apply(text).build())
+    surfCoreApi.sendText(this, SurfComponentBuilder(text))
 }

--- a/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/util/surf-player-util.kt
+++ b/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/util/surf-player-util.kt
@@ -1,0 +1,9 @@
+package dev.slne.surf.core.api.common.util
+
+import dev.slne.surf.core.api.common.player.SurfPlayer
+import dev.slne.surf.core.api.common.surfCoreApi
+import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
+
+fun SurfPlayer.sendText(text: SurfComponentBuilder.() -> Unit) {
+    surfCoreApi.sendText(this, SurfComponentBuilder().apply(text).build())
+}

--- a/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/util/surf-player-util.kt
+++ b/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/util/surf-player-util.kt
@@ -4,6 +4,6 @@ import dev.slne.surf.core.api.common.player.SurfPlayer
 import dev.slne.surf.core.api.common.surfCoreApi
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 
-fun SurfPlayer.sendText(text: SurfComponentBuilder.() -> Unit) {
+inline fun SurfPlayer.sendText(text: SurfComponentBuilder.() -> Unit) {
     surfCoreApi.sendText(this, SurfComponentBuilder().apply(text).build())
 }

--- a/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/SurfCoreApiImpl.kt
+++ b/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/SurfCoreApiImpl.kt
@@ -4,8 +4,11 @@ import dev.slne.surf.core.api.common.SurfCoreApi
 import dev.slne.surf.core.api.common.player.SurfPlayer
 import dev.slne.surf.core.api.common.server.SurfServer
 import dev.slne.surf.core.core.common.player.surfPlayerService
+import dev.slne.surf.core.core.common.redis.event.SurfPlayerMessageRedisEvent
+import dev.slne.surf.core.core.common.redis.redisApi
 import dev.slne.surf.core.core.common.server.surfServerService
 import it.unimi.dsi.fastutil.objects.ObjectSet
+import net.kyori.adventure.text.Component
 import java.util.*
 
 abstract class SurfCoreApiImpl : SurfCoreApi {
@@ -36,5 +39,9 @@ abstract class SurfCoreApiImpl : SurfCoreApi {
 
     override fun getServers(): ObjectSet<SurfServer> {
         return surfServerService.servers
+    }
+
+    override fun sendText(player: SurfPlayer, text: Component) {
+        redisApi.publishEvent(SurfPlayerMessageRedisEvent(player.uuid, text))
     }
 }

--- a/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/redis/RedisLoader.kt
+++ b/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/redis/RedisLoader.kt
@@ -12,8 +12,10 @@ class RedisLoader {
     fun load() {
     }
 
-    fun connect() {
+    fun connect(vararg extraListeners: Any) {
         redisApi.subscribeToEvents(LocalSurfEventBusListener)
+        extraListeners.forEach { redisApi.subscribeToEvents(it) }
+
         redisApi.freezeAndConnect()
     }
 

--- a/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/redis/event/SurfPlayerMessageRedisEvent.kt
+++ b/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/redis/event/SurfPlayerMessageRedisEvent.kt
@@ -1,0 +1,10 @@
+package dev.slne.surf.core.core.common.redis.event
+
+import dev.slne.surf.redis.event.RedisEvent
+import net.kyori.adventure.text.Component
+import java.util.*
+
+data class SurfPlayerMessageRedisEvent(
+    val uuid: UUID,
+    val message: Component
+) : RedisEvent()

--- a/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/redis/event/SurfPlayerMessageRedisEvent.kt
+++ b/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/redis/event/SurfPlayerMessageRedisEvent.kt
@@ -4,6 +4,7 @@ import dev.slne.surf.redis.event.RedisEvent
 import net.kyori.adventure.text.Component
 import java.util.*
 
+@Serializable
 data class SurfPlayerMessageRedisEvent(
     val uuid: UUID,
     val message: Component

--- a/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/redis/event/SurfPlayerMessageRedisEvent.kt
+++ b/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/redis/event/SurfPlayerMessageRedisEvent.kt
@@ -1,11 +1,13 @@
 package dev.slne.surf.core.core.common.redis.event
 
 import dev.slne.surf.redis.event.RedisEvent
-import net.kyori.adventure.text.Component
+import dev.slne.surf.surfapi.core.api.serializer.adventure.component.SerializableComponent
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 import java.util.*
 
 @Serializable
 data class SurfPlayerMessageRedisEvent(
-    val uuid: UUID,
-    val message: Component
+    val uuid: @Contextual UUID,
+    val message: SerializableComponent
 ) : RedisEvent()

--- a/surf-core-velocity/src/main/kotlin/dev/slne/surf/core/velocity/VelocityMain.kt
+++ b/surf-core-velocity/src/main/kotlin/dev/slne/surf/core/velocity/VelocityMain.kt
@@ -23,6 +23,7 @@ import dev.slne.surf.core.core.common.player.surfPlayerService
 import dev.slne.surf.core.core.common.redis.redisLoader
 import dev.slne.surf.core.core.common.server.surfServerService
 import dev.slne.surf.core.velocity.listener.ConnectionListener
+import dev.slne.surf.core.velocity.redis.listener.VelocitySurfPlayerRedisListener
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Path
@@ -43,7 +44,7 @@ class VelocityMain @Inject constructor(
         redisLoader.load()
         surfPlayerService.init()
         surfServerService.init()
-        redisLoader.connect()
+        redisLoader.connect(VelocitySurfPlayerRedisListener)
 
         val server = SurfServer(
             name = surfServerConfig.serverName,

--- a/surf-core-velocity/src/main/kotlin/dev/slne/surf/core/velocity/redis/listener/VelocitySurfPlayerRedisListener.kt
+++ b/surf-core-velocity/src/main/kotlin/dev/slne/surf/core/velocity/redis/listener/VelocitySurfPlayerRedisListener.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.core.velocity.redis.listener
+
+import dev.slne.surf.core.api.common.event.SurfEventHandler
+import dev.slne.surf.core.core.common.redis.event.SurfPlayerMessageRedisEvent
+import dev.slne.surf.core.velocity.plugin
+import kotlin.jvm.optionals.getOrNull
+
+object VelocitySurfPlayerRedisListener {
+    @SurfEventHandler
+    fun onSurfPlayerMessage(event: SurfPlayerMessageRedisEvent) {
+        plugin.proxy.getPlayer(event.uuid).getOrNull()?.sendMessage(event.message)
+    }
+}

--- a/surf-core-velocity/src/main/kotlin/dev/slne/surf/core/velocity/redis/listener/VelocitySurfPlayerRedisListener.kt
+++ b/surf-core-velocity/src/main/kotlin/dev/slne/surf/core/velocity/redis/listener/VelocitySurfPlayerRedisListener.kt
@@ -6,7 +6,7 @@ import dev.slne.surf.core.velocity.plugin
 import kotlin.jvm.optionals.getOrNull
 
 object VelocitySurfPlayerRedisListener {
-    @SurfEventHandler
+    @OnRedisEvent
     fun onSurfPlayerMessage(event: SurfPlayerMessageRedisEvent) {
         plugin.proxy.getPlayer(event.uuid).getOrNull()?.sendMessage(event.message)
     }

--- a/surf-core-velocity/src/main/kotlin/dev/slne/surf/core/velocity/redis/listener/VelocitySurfPlayerRedisListener.kt
+++ b/surf-core-velocity/src/main/kotlin/dev/slne/surf/core/velocity/redis/listener/VelocitySurfPlayerRedisListener.kt
@@ -1,8 +1,8 @@
 package dev.slne.surf.core.velocity.redis.listener
 
-import dev.slne.surf.core.api.common.event.SurfEventHandler
 import dev.slne.surf.core.core.common.redis.event.SurfPlayerMessageRedisEvent
 import dev.slne.surf.core.velocity.plugin
+import dev.slne.surf.redis.event.OnRedisEvent
 import kotlin.jvm.optionals.getOrNull
 
 object VelocitySurfPlayerRedisListener {


### PR DESCRIPTION
- Introduced `VelocitySurfPlayerRedisListener` for handling Redis player messages.
- Added `SurfPlayerMessageRedisEvent` for publishing player messages via Redis.
- Extended `SurfCoreApi` with a `sendText` method to support text messaging.
- Added utility extension for `SurfPlayer` to simplify sending messages.
- Updated `RedisLoader` to support additional listeners.
- Bumped version to `1.21.11-1.1.2-SNAPSHOT`.