### PR TITLE
feat: add event handling capabilities to `SurfCoreApi`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.11-1.1.4-SNAPSHOT
+version=1.21.11-1.1.5-SNAPSHOT

--- a/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/SurfCoreApi.kt
+++ b/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/SurfCoreApi.kt
@@ -1,11 +1,13 @@
 package dev.slne.surf.core.api.common
 
+import dev.slne.surf.core.api.common.event.SurfEvent
 import dev.slne.surf.core.api.common.player.SurfPlayer
 import dev.slne.surf.core.api.common.server.SurfServer
 import dev.slne.surf.surfapi.core.api.util.requiredService
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.Component
 import java.util.*
+import kotlin.reflect.KClass
 
 val surfCoreApi = requiredService<SurfCoreApi>()
 
@@ -21,6 +23,10 @@ interface SurfCoreApi {
     fun getServerByName(name: String): SurfServer?
     fun getServerByCategory(category: String): ObjectSet<SurfServer>
     fun getServers(): ObjectSet<SurfServer>
+
+    fun registerListener(listener: Any)
+    fun fireEvent(event: SurfEvent)
+    fun subscribe(eventClass: KClass<out SurfEvent>, handler: (SurfEvent) -> Unit)
 
     /**
      * Sends a text message to the given player via the cross-server messaging system.

--- a/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/util/surf-event-util.kt
+++ b/surf-core-api/surf-core-api-common/src/main/kotlin/dev/slne/surf/core/api/common/util/surf-event-util.kt
@@ -1,0 +1,10 @@
+package dev.slne.surf.core.api.common.util
+
+import dev.slne.surf.core.api.common.SurfCoreApi
+import dev.slne.surf.core.api.common.event.SurfEvent
+
+inline fun <reified T : SurfEvent> SurfCoreApi.subscribe(noinline handler: (T) -> Unit) {
+    subscribe(T::class) { event ->
+        handler(event as T)
+    }
+}

--- a/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/SurfCoreApiImpl.kt
+++ b/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/SurfCoreApiImpl.kt
@@ -1,8 +1,10 @@
 package dev.slne.surf.core.core.common
 
 import dev.slne.surf.core.api.common.SurfCoreApi
+import dev.slne.surf.core.api.common.event.SurfEvent
 import dev.slne.surf.core.api.common.player.SurfPlayer
 import dev.slne.surf.core.api.common.server.SurfServer
+import dev.slne.surf.core.core.common.event.surfEventBus
 import dev.slne.surf.core.core.common.player.surfPlayerService
 import dev.slne.surf.core.core.common.redis.event.SurfPlayerMessageRedisEvent
 import dev.slne.surf.core.core.common.redis.redisApi
@@ -10,6 +12,7 @@ import dev.slne.surf.core.core.common.server.surfServerService
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.Component
 import java.util.*
+import kotlin.reflect.KClass
 
 abstract class SurfCoreApiImpl : SurfCoreApi {
     override fun getOnlinePlayers(): ObjectSet<SurfPlayer> = surfPlayerService.players
@@ -43,5 +46,17 @@ abstract class SurfCoreApiImpl : SurfCoreApi {
 
     override fun sendText(player: SurfPlayer, text: Component) {
         redisApi.publishEvent(SurfPlayerMessageRedisEvent(player.uuid, text))
+    }
+
+    override fun subscribe(eventClass: KClass<out SurfEvent>, handler: (SurfEvent) -> Unit) {
+        surfEventBus.subscribe(eventClass, handler)
+    }
+
+    override fun registerListener(listener: Any) {
+        surfEventBus.registerListener(listener)
+    }
+
+    override fun fireEvent(event: SurfEvent) {
+        surfEventBus.fire(event)
     }
 }

--- a/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/event/SurfEventBus.kt
+++ b/surf-core-core/surf-core-core-common/src/main/kotlin/dev/slne/surf/core/core/common/event/SurfEventBus.kt
@@ -52,6 +52,7 @@ class SurfEventBus {
         listeners.computeIfAbsent(eventClass) { mutableListOf() }.add(handler)
     }
 
+
     fun fireLocal(event: SurfEvent) {
         listeners[event::class]?.forEach { handler ->
             handler(event)


### PR DESCRIPTION
- Introduced methods `registerListener`, `fireEvent`, and `subscribe` in `SurfCoreApi`.
- Added `surf-event-util` with inline utility for event subscriptions.
- Updated `SurfCoreApiImpl` to integrate with `SurfEventBus` for event handling.
- Bumped version to `1.21.11-1.1.5-SNAPSHOT`.