### PR TITLE
Refactor HubCommand to select server with least players

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=2.4.0
+version=2.4.1

--- a/surf-core-paper/src/main/kotlin/dev/slne/surf/core/paper/command/HubCommand.kt
+++ b/surf-core-paper/src/main/kotlin/dev/slne/surf/core/paper/command/HubCommand.kt
@@ -20,20 +20,29 @@ fun hubCommand() = commandTree("hub") {
             info("Du wirst zum Hub gesendet...")
         }
 
-        val server = SurfCoreApi.getServerWithLeastPlayers("lobby")
+        val servers = SurfCoreApi.getServerByCategory("lobby")
+            .sortedBy { it.getPlayerCount() }
 
-        if (server == null) {
+        if (servers.isEmpty()) {
             player.sendText {
                 appendCorePrefix()
-                error("Es konnte kein Hub-Server gefunden werden.")
+                error("Es konnte kein passender Hub-Server gefunden werden.")
             }
             return@playerExecutor
         }
 
         plugin.launch {
-            val result = SurfCoreApi.sendPlayerAwaiting(player.surfPlayer, server)
+            var success = false
 
-            if (result.isSuccessful()) {
+            for (server in servers) {
+                val result = SurfCoreApi.sendPlayerAwaiting(player.surfPlayer, server)
+                if (result.isSuccessful()) {
+                    success = true
+                    break
+                }
+            }
+
+            if (success) {
                 player.sendText {
                     appendCorePrefix()
                     success("Du wurdest erfolgreich zum Hub gesendet.")
@@ -41,16 +50,7 @@ fun hubCommand() = commandTree("hub") {
             } else {
                 player.sendText {
                     appendCorePrefix()
-                    error("Es gab ein Problem beim Senden zum Hub")
-
-                    result.velocityMessage.let {
-                        if (it != null) {
-                            error(": ")
-                            append(it)
-                        } else {
-                            error(".")
-                        }
-                    }
+                    error("Es konnte kein passender Hub-Server gefunden werden.")
                 }
             }
         }


### PR DESCRIPTION
This pull request updates the logic for sending a player to a Hub server in the `hubCommand`. Instead of selecting only the single lobby server with the fewest players, it now retrieves all available lobby servers, sorts them by player count, and attempts to send the player to each in order until successful. This improves reliability in cases where some servers may be unavailable.

**Improvements to Hub server selection and player transfer:**

* Changed the server selection logic in `HubCommand.kt` to try all available lobby servers (sorted by player count) instead of just the one with the least players, increasing the chance of a successful transfer.
* Improved error handling and user feedback: if no suitable Hub server is found or all transfer attempts fail, the player receives a clear error message.